### PR TITLE
Update using OutDir

### DIFF
--- a/steeltoe-sample/src/planet-weather-provider/Microsoft.Azure.SpringCloud.Sample.PlanetWeatherProvider.csproj
+++ b/steeltoe-sample/src/planet-weather-provider/Microsoft.Azure.SpringCloud.Sample.PlanetWeatherProvider.csproj
@@ -14,14 +14,14 @@
 
   <Target Name="Build-Zip" AfterTargets="Build">
     <ZipDirectory
-      SourceDirectory="$(OutputPath)"
+      SourceDirectory="$(OutDir)"
       DestinationFile="$(MSBuildProjectDirectory)/build-deploy.zip"
       Overwrite="true" />
   </Target>
 
   <Target Name="Publish-Zip" AfterTargets="Publish">
     <ZipDirectory
-      SourceDirectory="$(OutputPath)/publish"
+      SourceDirectory="$(OutDir)/publish"
       DestinationFile="$(MSBuildProjectDirectory)/publish-deploy.zip"
       Overwrite="true" />
   </Target>


### PR DESCRIPTION
Using OutDir enables someone who is specifying and output option in `dotnet build` or `dotnet publish` to work.  Otherwise current project fails.